### PR TITLE
Fix error with bcmath

### DIFF
--- a/docker-php-ext-enable
+++ b/docker-php-ext-enable
@@ -56,7 +56,7 @@ for module in "${modules[@]}"; do
 		continue
 	fi
 
-	ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
+	ini="$PHP_INI_DIR/conf.d/docker-php-ext-$ext.ini"
 	if ! grep -q "$line" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi


### PR DESCRIPTION
Based on this issue: https://github.com/eugeneware/docker-php-5.3-apache/issues/2

Here is the fix for bcmath
Fixed docker-php-ext-enable adding `$PHP_INI_DIR` to ini var.